### PR TITLE
Hash specification of external GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
CVE-2025-30066
If malicious changes are made to an external GHA and it is released in the same version, the GHA will run using the version with the malicious changes.
Specify the commit hash explicitly to avoid unintended module downloads.

use https://github.com/suzuki-shunsuke/pinact